### PR TITLE
expose all arrow dimensions in interface

### DIFF
--- a/blender_kitti/__init__.py
+++ b/blender_kitti/__init__.py
@@ -8,6 +8,7 @@ from .scene_setup import setup_scene, add_cameras_default
 from .system_setup import setup_system
 from .object_spotlight import add_spotlight_ground
 from .cli import process_file
+import numpy as np
 
 
 __all__ = [
@@ -20,3 +21,26 @@ __all__ = [
     "add_spotlight_ground",
     "process_file",
 ]
+
+
+def calc_distances(p0, points):
+    return ((p0 - points) ** 2).sum(axis=1)
+
+
+def furthest_point_sampling_thresh(pts, dist_thresh: float = 0.1):
+    farthest_pts = []
+    farthest_pts_idxs = []
+    first_idx = np.random.randint(len(pts))
+    farthest_pts_idxs.append(first_idx)
+    farthest_pts.append(pts[first_idx])
+    distances = calc_distances(farthest_pts[0], pts)
+    while True:
+        farthest_pt_idx = np.argmax(distances)
+        if distances[farthest_pt_idx] < dist_thresh:
+            break
+        farthest_pts.append(pts[farthest_pt_idx])
+        farthest_pts_idxs.append(farthest_pt_idx)
+        distances = np.minimum(distances, calc_distances(farthest_pts[-1], pts))
+    return np.stack(farthest_pts, axis=0), np.array(farthest_pts_idxs)
+
+

--- a/blender_kitti/particles.py
+++ b/blender_kitti/particles.py
@@ -374,6 +374,10 @@ def add_flow_mesh(
     flow: np.ndarray,
     colors_rgba: np.ndarray = None,
     name_prefix: str = "flow",
+    arrow_shaft_diameter: float = 0.05,
+    arrow_shaft_length: float = 1.0,
+    arrow_head_height: float = 0.2,
+    arrow_head_diameter: float = 0.15,
     scene,
     mathutils,
     bpy,
@@ -396,31 +400,28 @@ def add_flow_mesh(
         colors_rgba = colors_rgba.astype(np.float32)
 
     # arrow shaft
-    shaft_diameter: float = 0.05
-    shaft_length: float = 1.0
     arrow_shaft = bmesh.new()
     bmesh.ops.create_cone(
         arrow_shaft,
         cap_ends=True,
         cap_tris=False,
         segments=10,
-        diameter1=shaft_diameter,
-        diameter2=shaft_diameter,
-        depth=shaft_length,
+        diameter1=arrow_shaft_diameter,
+        diameter2=arrow_shaft_diameter,
+        depth=arrow_shaft_length,
         calc_uvs=False,
     )
 
     # arrow head
-    head_height: float = 0.2
     arrow_head = bmesh.new()
     bmesh.ops.create_cone(
         arrow_head,
         cap_ends=True,
         cap_tris=False,
         segments=10,
-        diameter1=3.0 * shaft_diameter,
+        diameter1=arrow_head_diameter,
         diameter2=0.0,
-        depth=head_height,
+        depth=arrow_head_height,
         calc_uvs=False,
     )
 


### PR DESCRIPTION
I forgot to expose the flow arrow dimensions of add_flow_mesh when I first implemented it. This is inconvenient, as you have to edit the source code to get different arrow shapes. This PR fixes that. Thanks!